### PR TITLE
New Terabox Api And Domains

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -85,6 +85,10 @@ domain_dict = {
         "gibibox.com",
         "goaibox.com",
         "terasharelink.com",
+        "teraboxlink.com",
+        "freeterabox.com",
+        "1024terabox.com",
+        "teraboxshare.com"
     ],
     "filewish": [
         "filelions.co",
@@ -450,6 +454,8 @@ def terabox(url, video_quality="HD Video", save_dir="HD_Video"):
         "https://ytshorts.savetube.me/api/v1/terabox-downloader",
         f"https://teraboxvideodownloader.nepcoderdevs.workers.dev/?url={terabox_url}",
         f"https://terabox.udayscriptsx.workers.dev/?url={terabox_url}",
+        f"https://mavimods.serv00.net/Mavialt.php?url={terabox_url}",
+        f"https://mavimods.serv00.net/Mavitera.php?url={terabox_url}",
     ]
 
     headers = {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce new Terabox domains and enhance the Terabox API with additional URL endpoints for improved video downloading capabilities.

New Features:
- Add support for new Terabox domains including teraboxlink.com, freeterabox.com, 1024terabox.com, and teraboxshare.com.

Enhancements:
- Enhance the Terabox API by adding new URL endpoints for video downloading.

<!-- Generated by sourcery-ai[bot]: end summary -->