### PR TITLE
heroku team deploy added

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ on:
       HEROKU_EMAIL:
         description: "Heroku email address"
         required: true
-      TEAM:
+      HK_TEAM_NAME:
         description: "Heroku Team Name"
         required: false
       BOT_TOKEN:
@@ -45,7 +45,7 @@ jobs:
           heroku_api_key: ${{inputs.HEROKU_API_KEY}}
           heroku_app_name: ${{inputs.HEROKU_APP_NAME}}
           heroku_email: ${{inputs.HEROKU_EMAIL}}
-          team: ${{ inputs.TEAM != '' && format('team={0}', inputs.TEAM) || '' }}
+          team: ${{ inputs.HK_TEAM_NAME != '' && format('team={0}', inputs.HK_TEAM_NAME) || '' }}
           usedocker: true
           docker_heroku_process_type: web
           stack: "container"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
           heroku_api_key: ${{inputs.HEROKU_API_KEY}}
           heroku_app_name: ${{inputs.HEROKU_APP_NAME}}
           heroku_email: ${{inputs.HEROKU_EMAIL}}
-          team : ${{inputs.TEAM}}
+          team: ${{ inputs.TEAM != '' && format('team={0}', inputs.TEAM) || '' }}
           usedocker: true
           docker_heroku_process_type: web
           stack: "container"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,9 @@ on:
       HEROKU_EMAIL:
         description: "Heroku email address"
         required: true
+      TEAM:
+        description: "Heroku Team Name"
+        required: false
       BOT_TOKEN:
         description: "Telegram bot token"
         required: true
@@ -42,6 +45,7 @@ jobs:
           heroku_api_key: ${{inputs.HEROKU_API_KEY}}
           heroku_app_name: ${{inputs.HEROKU_APP_NAME}}
           heroku_email: ${{inputs.HEROKU_EMAIL}}
+          team : ${{inputs.TEAM}}
           usedocker: true
           docker_heroku_process_type: web
           stack: "container"


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the deployment workflow to support Heroku team deployments by adding an optional input for the Heroku team name.

Deployment:
- Add support for specifying a Heroku team name in the deployment workflow, allowing deployments to be associated with a specific Heroku team.

<!-- Generated by sourcery-ai[bot]: end summary -->